### PR TITLE
fix(#437): resolve bulk ids before generating AppleScript, drop the unindexed arm

### DIFF
--- a/src/apple_mail_fast_mcp/mail_connector.py
+++ b/src/apple_mail_fast_mcp/mail_connector.py
@@ -811,29 +811,30 @@ def _bulk_repeat_block(
         source_mailbox: Source mailbox name, or None.
         actions: One or more AppleScript statements to run inside the
             loop once a message is matched (under `if matched then`).
-            Each id is matched in TWO sequential attempts — first by
-            Mail's internal numeric `id`, then (if that misses) by the
-            RFC 5322 `message id`. This lets callers pass either form:
-            read tools hand back the RFC Message-ID on the IMAP path,
-            which a numeric `id` never equals (the cause of silent
-            `updated:0` patches; #205-family). The two predicates are
-            kept in SEPARATE `whose` clauses on purpose — combining them
-            as `whose (id is X or message id is X)` makes Mail's query
-            compiler fail the whole filter when X is a non-numeric RFC
-            id (the `id is X` integer comparison poisons the `or`),
-            matching nothing. The `message id` arm itself queries BOTH
-            the bare and `<bracketed>` forms (`message id is A or message
-            id is B` — safe, both are string comparisons), mirroring
-            `find_message_by_message_id`: IMAP-backed accounts store the
-            id bare, but other paths may store it bracketed per RFC 5322
-            (#232). The counter increment is appended automatically.
+            Ids are matched ONLY by Mail's internal numeric `id`, which is
+            an integer and INDEXED, so the match is instant. The counter
+            increment is appended automatically.
 
-            Performance: on the cross-scan path (no `source_mailbox`) the
-            `message id` fallback is NOT indexed (~20s/mailbox on a real
-            account; see APPLESCRIPT_GOTCHAS.md) and fires once per mailbox
-            for any RFC id, since the numeric `id` arm always misses for
-            those. Callers holding an RFC id should pass `account` +
-            `source_mailbox` to take the narrow single-mailbox path.
+            **Callers must pass numeric ids.** Route the caller's list
+            through `AppleMailConnector._resolve_bulk_ids` first — it
+            converts RFC 5322 Message-IDs (what read tools emit on the IMAP
+            path, #148) to internal ids via the indexed resolver.
+
+            This block used to carry a second arm matching `message id`
+            inline, so either id form worked without a resolver round-trip
+            (#205-family). That arm was the #437 freeze: `message id` is
+            UNINDEXED, and AppleScript runs on Mail's UI thread, so it
+            loaded every message in scope — once per id, up to the 100-item
+            bulk cap — on BOTH branches. Scoping to `source_mailbox` only
+            removed the mailbox-count multiplier, not the scan: `sourceMb`
+            is routinely a 33,569-message INBOX.
+
+            Historical note, in case anyone reintroduces a dual match: the
+            two predicates were deliberately in SEPARATE `whose` clauses,
+            never combined as `whose (id is X or message id is X)` — the
+            integer comparison poisons the `or` for a non-numeric RFC id and
+            Mail's query compiler then fails the whole filter, matching
+            nothing.
         counter_var: Name of the AppleScript counter variable (e.g.
             "updateCount", "moveCount") that gets incremented per success.
 
@@ -889,14 +890,6 @@ def _bulk_repeat_block(
             f"                    set msg to first message of sourceMb whose id is mid\n"
             f"                    set matched to true\n"
             f"                end try\n"
-            f"                if not matched then\n"
-            f"                    try\n"
-            f"                        set midBare to mid\n"
-            f'                        if midBare starts with "<" and midBare ends with ">" then set midBare to text 2 thru -2 of midBare\n'
-            f'                        set msg to first message of sourceMb whose (message id is midBare or message id is ("<" & midBare & ">"))\n'
-            f"                        set matched to true\n"
-            f"                    end try\n"
-            f"                end if\n"
             f"                if matched then\n"
             f"{action_lines}\n"
             f"{_success_tail(' ' * 20)}\n"
@@ -917,14 +910,6 @@ def _bulk_repeat_block(
         f"                            set msg to first message of mb whose id is mid\n"
         f"                            set matched to true\n"
         f"                        end try\n"
-        f"                        if not matched then\n"
-        f"                            try\n"
-        f"                                set midBare to mid\n"
-        f'                                if midBare starts with "<" and midBare ends with ">" then set midBare to text 2 thru -2 of midBare\n'
-        f'                                set msg to first message of mb whose (message id is midBare or message id is ("<" & midBare & ">"))\n'
-        f"                                set matched to true\n"
-        f"                            end try\n"
-        f"                        end if\n"
         f"                        if matched then\n"
         f"{action_lines}\n"
         f"{_success_tail(' ' * 28)}\n"
@@ -2501,6 +2486,11 @@ class AppleMailConnector:
         )
 
         # Build list of IDs (sanitize and escape each)
+        # #437: resolve RFC Message-IDs to Mail's internal numeric ids so
+        # the emitted match is the INDEXED `whose id is N`. Must come AFTER
+        # any IMAP fast path above — those batch the RFC ids themselves.
+        message_ids = self._resolve_bulk_ids(message_ids)
+
         id_list = ", ".join(
             f'"{escape_applescript_string(sanitize_input(mid))}"'
             for mid in message_ids
@@ -3994,6 +3984,11 @@ class AppleMailConnector:
         mailbox_safe = escape_applescript_string(
             sanitize_input(destination_mailbox)
         )
+        # #437: resolve RFC Message-IDs to Mail's internal numeric ids so
+        # the emitted match is the INDEXED `whose id is N`. Must come AFTER
+        # any IMAP fast path above — those batch the RFC ids themselves.
+        message_ids = self._resolve_bulk_ids(message_ids)
+
         id_list = ", ".join(
             f'"{escape_applescript_string(sanitize_input(mid))}"'
             for mid in message_ids
@@ -4069,6 +4064,11 @@ class AppleMailConnector:
 
         flag_index = get_flag_index(flag_color)
         flagged_status = "true" if flag_color != "none" else "false"
+        # #437: resolve RFC Message-IDs to Mail's internal numeric ids so
+        # the emitted match is the INDEXED `whose id is N`. Must come AFTER
+        # any IMAP fast path above — those batch the RFC ids themselves.
+        message_ids = self._resolve_bulk_ids(message_ids)
+
         id_list = ", ".join(
             f'"{escape_applescript_string(sanitize_input(mid))}"'
             for mid in message_ids
@@ -4235,6 +4235,11 @@ class AppleMailConnector:
             actions=actions,
             counter_var="updateCount",
         )
+
+        # #437: resolve RFC Message-IDs to Mail's internal numeric ids so
+        # the emitted match is the INDEXED `whose id is N`. Must come AFTER
+        # any IMAP fast path above — those batch the RFC ids themselves.
+        message_ids = self._resolve_bulk_ids(message_ids)
 
         id_list = ", ".join(
             f'"{escape_applescript_string(sanitize_input(mid))}"'
@@ -4613,6 +4618,11 @@ class AppleMailConnector:
             )
             if imap_count is not None:
                 return imap_count
+
+        # #437: resolve RFC Message-IDs to Mail's internal numeric ids so
+        # the emitted match is the INDEXED `whose id is N`. Must come AFTER
+        # any IMAP fast path above — those batch the RFC ids themselves.
+        message_ids = self._resolve_bulk_ids(message_ids)
 
         id_list = ", ".join(
             f'"{escape_applescript_string(sanitize_input(mid))}"'
@@ -6384,6 +6394,70 @@ class AppleMailConnector:
             f"unreachable, or a non-RFC reply seed). {tail} Configure or "
             "repair IMAP for the account with `apple-mail-fast-mcp setup-imap`."
         )
+
+    def _resolve_bulk_ids(self, message_ids: list[str]) -> list[str]:
+        """Resolve RFC 5322 Message-IDs to Mail's internal numeric ids so the
+        bulk AppleScript can match on the INDEXED ``whose id is N`` (#437).
+
+        The alternative — matching ``message id`` inline, which is what
+        `_bulk_repeat_block` used to do — is UNINDEXED. AppleScript runs on
+        Mail's UI thread, so that match loads every message in scope (33,569
+        in Gmail's INBOX, 62,085 in All Mail) once per id, up to the 100-item
+        bulk cap. Mail freezes, and a mid-batch freeze leaves the mutation
+        partially applied.
+
+        This reverses the #205-family decision to match inline rather than pay
+        "a separate resolver round-trip". That was sound when resolving meant
+        an all-mailbox scan; since #434 the resolver is an indexed IMAP lookup
+        plus a binary search, while the inline match still freezes Mail.
+
+        **Call this AFTER the IMAP fast paths**, never before: those want the
+        RFC ids and batch them through ``_resolve_uids_batch`` /
+        ``_or_message_id_criteria`` (#316) into one OR-SEARCH per 50 ids.
+        Handing them numeric ids would defeat that batching.
+
+        Numeric ids pass through untouched — they already take the indexed
+        path and must not acquire a round-trip they never needed.
+
+        Failure handling mirrors #425:
+          * resolved            -> use it
+          * ``None`` (absent)   -> drop; matches the tools' best-effort
+                                   partial-success convention (they return a
+                                   count, not per-id errors)
+          * indeterminate       -> drop from this batch, but remember
+
+        Raises:
+            MailAnchorLookupIncompleteError: nothing resolved AND at least one
+                id could not be checked. Reporting ``updated: 0`` there would
+                be #425's "couldn't check presented as doesn't exist" again.
+        """
+        resolved: list[str] = []
+        indeterminate: list[str] = []
+        for mid in message_ids:
+            if "@" not in mid:
+                resolved.append(mid)
+                continue
+            try:
+                internal = self.find_message_by_message_id(mid)
+            except MailAnchorLookupIncompleteError as exc:
+                logger.warning(
+                    "bulk id %s could not be resolved (%s); skipping it in "
+                    "this batch", mid, exc,
+                )
+                indeterminate.append(mid)
+                continue
+            if internal is not None:
+                resolved.append(internal)
+        if not resolved and indeterminate:
+            raise MailAnchorLookupIncompleteError(
+                f"None of the {len(message_ids)} requested message(s) could "
+                f"be resolved, and {len(indeterminate)} could not be checked "
+                f"at all ({', '.join(indeterminate[:3])}"
+                f"{'...' if len(indeterminate) > 3 else ''}). Reporting 0 "
+                "updated would imply they do not exist. This is usually a "
+                "transient IMAP timeout — retry."
+            )
+        return resolved
 
     def _draft_poll_iterations(self) -> int:
         """How many times the AppleScript id-diff rescans the unified drafts

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -2729,6 +2729,92 @@ class TestAnchorLookupIncompleteIntegration:
         assert isinstance(thread, list) and len(thread) >= 1
 
 
+class TestBulkRfcIdDoesNotFreezeMail:
+    """#437: a bulk mutation given RFC Message-IDs and NO account/mailbox is
+    the exact shape that froze Mail.
+
+    `_bulk_repeat_block` used to match `message id` inline when the numeric
+    `id` arm missed — which it always does for an RFC id. That match is
+    unindexed and AppleScript runs on Mail's UI thread, so it loaded every
+    message in scope (33,569 in Gmail's INBOX, 62,085 in All Mail) once per
+    id. Ids are now resolved up front, so the emitted match is the indexed
+    `whose id is N`.
+
+    `flag_color` is used deliberately: IMAP cannot set Mail's
+    `\\$MailFlagBit*` keywords, so it is guaranteed to take the AppleScript
+    fallback rather than an IMAP fast path.
+    """
+
+    def test_bulk_flag_by_rfc_id_completes_and_keeps_mail_responsive(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        import subprocess
+        import threading
+
+        rows = connector.search_messages(
+            account=test_account, mailbox="INBOX", limit=1
+        )
+        if not rows:
+            pytest.skip(f"{test_account} INBOX has no messages")
+        rfc_id = rows[0].get("rfc_message_id") or rows[0].get("id")
+        if not rfc_id or "@" not in rfc_id:
+            pytest.skip("test_account is not on the IMAP path")
+
+        done = threading.Event()
+        result: dict[str, Any] = {}
+
+        def _bulk() -> None:
+            try:
+                # No account / source_mailbox on purpose — the freezing shape.
+                result["count"] = connector.update_message(
+                    [str(rfc_id)], flag_color="orange"
+                )
+            except BaseException as exc:  # noqa: BLE001 - reported below
+                result["error"] = exc
+            finally:
+                done.set()
+
+        t = threading.Thread(target=_bulk, daemon=True)
+        t.start()
+        try:
+            probe_start = time.monotonic()
+            probe = subprocess.run(
+                ["/usr/bin/osascript", "-e",
+                 'tell application "Mail" to return (count of accounts) as text'],
+                capture_output=True, text=True, timeout=30,
+            )
+            probe_elapsed = time.monotonic() - probe_start
+        except subprocess.TimeoutExpired:
+            pytest.fail(
+                "Mail did not answer a trivial AppleScript within 30s while a "
+                "bulk RFC-id update was running — the UI thread is blocked, "
+                "i.e. the #437 freeze is back"
+            )
+        finally:
+            done.wait(timeout=180)
+        t.join(timeout=5)
+
+        assert probe.returncode == 0, f"probe failed: {probe.stderr}"
+        assert probe_elapsed < 25.0, (
+            f"Mail took {probe_elapsed:.1f}s to answer during the bulk "
+            "update — the UI thread is being starved (#437)"
+        )
+        assert "error" not in result, f"bulk update raised: {result.get('error')}"
+        # >= 1, not == 1: the cross-scan visits every mailbox of every account
+        # and has no `exit repeat` after a match, so a Gmail message visible
+        # under several labels increments the counter once per mailbox. That
+        # over-count predates #437 (the old unindexed arm matched the same way
+        # in each mailbox) and is tracked separately — what this test pins is
+        # that the id RESOLVED and the mutation ran without freezing Mail.
+        assert result.get("count", 0) >= 1, (
+            f"expected at least 1 message flagged, got {result.get('count')} "
+            "— the RFC id did not resolve to a real message"
+        )
+
+        # Leave no trace: clear the flag we set.
+        connector.update_message([str(rfc_id)], flag_color="none")
+
+
 class TestGetThreadPartialFlagIntegration:
     """#420: a degraded thread must announce itself against real Mail.
 

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -63,9 +63,28 @@ class TestAppleMailConnector:
     """Tests for AppleMailConnector."""
 
     @pytest.fixture
-    def connector(self) -> AppleMailConnector:
-        """Create a connector instance."""
-        return AppleMailConnector(timeout=30)
+    def connector(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> AppleMailConnector:
+        """Create a connector instance.
+
+        #437: the bulk-mutation tools now resolve RFC Message-IDs to Mail's
+        internal numeric ids before generating AppleScript (so the match is
+        the indexed `whose id is N` rather than the unindexed `message id`
+        scan that froze Mail). Tests in this class use placeholder ids like
+        `a@x` while exercising IMAP fast-path SELECTION, not resolution, and
+        mock the whole AppleScript layer — so an unstubbed resolver would try
+        a real `list_accounts` against a mocked `_run_applescript`.
+
+        Stub it to a fixed numeric id. Resolution itself is covered by
+        `TestResolveBulkIds`, and the "RFC ids never reach AppleScript"
+        guarantee by `TestBulkBlockHasNoUnindexedArm`.
+        """
+        c = AppleMailConnector(timeout=30)
+        monkeypatch.setattr(
+            c, "find_message_by_message_id", lambda mid: "1"
+        )
+        return c
 
     @patch("subprocess.run")
     def test_run_applescript_success(
@@ -4987,17 +5006,153 @@ class TestWhoseIdQuoting:
         mock_run.assert_not_called()
 
 
-class TestUpdateMessageMatchesRfcMessageId:
-    """Bug A / #205-family: the AppleScript pass must match the RFC 5322
-    ``message id`` as well as Mail's internal numeric ``id``.
+class TestResolveBulkIds:
+    """#437: resolve RFC Message-IDs to Mail's internal numeric ids BEFORE
+    generating AppleScript, so the emitted match is the indexed
+    `whose id is N` and the unindexed `message id` arm can be deleted.
 
-    Read tools hand back the RFC 5322 Message-ID on the IMAP path. The
-    AppleScript fallback used to match only ``whose id is msgId`` (numeric
-    ``id``), which an RFC string never equals — so flag/read patches that
-    can't use the IMAP fast path (e.g. ``flag_color``, which IMAP can't
-    set) matched nothing and silently returned ``updated:0``. Matching
-    ``(id is msgId or message id is msgId)`` in the same pass fixes it
-    with no extra round-trip (no per-id all-mailbox scan).
+    That arm is the freeze: `message id` is not indexed and AppleScript runs
+    on Mail's UI thread, so it loads every message in scope — 33,569 in
+    Gmail's INBOX, 62,085 in All Mail — once per id, up to the 100-item cap.
+
+    This reverses #205's "match inline, no separate resolver round-trip"
+    choice. That was reasonable when the resolver meant an all-mailbox scan;
+    since #434 the resolver is indexed IMAP + binary search, while the inline
+    match still freezes Mail.
+    """
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    def test_numeric_ids_pass_through_without_any_lookup(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Numeric ids already take Mail's INDEXED integer `id`. They must not
+        acquire an IMAP round-trip they never needed."""
+        calls: list[str] = []
+        monkeypatch.setattr(
+            connector, "find_message_by_message_id",
+            lambda mid: calls.append(mid) or "999",
+        )
+        assert connector._resolve_bulk_ids(["123", "456"]) == ["123", "456"]
+        assert calls == []
+
+    def test_rfc_ids_are_resolved_to_internal_ids(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            connector, "find_message_by_message_id", lambda mid: "160989"
+        )
+        assert connector._resolve_bulk_ids(["abc@example.com"]) == ["160989"]
+
+    def test_mixed_batch_resolves_only_the_rfc_ids(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            connector, "find_message_by_message_id", lambda mid: "777"
+        )
+        assert connector._resolve_bulk_ids(
+            ["123", "abc@example.com", "456"]
+        ) == ["123", "777", "456"]
+
+    def test_definitively_absent_id_is_dropped(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """None means IMAP answered: not present. Dropping it matches the
+        existing best-effort partial-success convention (the tools return a
+        count, not per-id errors)."""
+        monkeypatch.setattr(
+            connector, "find_message_by_message_id",
+            lambda mid: None if "gone" in mid else "555",
+        )
+        assert connector._resolve_bulk_ids(
+            ["gone@example.com", "here@example.com"]
+        ) == ["555"]
+
+    def test_all_indeterminate_raises_rather_than_reporting_zero(
+        self, connector: AppleMailConnector
+    ) -> None:
+        """#425's lesson: 'we could not check' must not be presented as
+        'nothing matched'. A silent updated:0 here would be that bug again."""
+        def _boom(mid: str) -> None:
+            raise MailAnchorLookupIncompleteError("probe timed out")
+
+        connector.find_message_by_message_id = _boom  # type: ignore[assignment]
+        with pytest.raises(MailAnchorLookupIncompleteError):
+            connector._resolve_bulk_ids(["a@x.com", "b@x.com"])
+
+    def test_partial_indeterminate_still_proceeds(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One unreachable id must not fail a batch that has real work."""
+        def _mixed(mid: str) -> str:
+            if mid.startswith("bad"):
+                raise MailAnchorLookupIncompleteError("timed out")
+            return "321"
+
+        monkeypatch.setattr(connector, "find_message_by_message_id", _mixed)
+        assert connector._resolve_bulk_ids(
+            ["bad@x.com", "good@x.com"]
+        ) == ["321"]
+
+
+class TestBulkBlockHasNoUnindexedArm:
+    """#437: the emitted AppleScript must never contain the unindexed
+    `message id` match, on EITHER branch.
+
+    The narrow (account + source_mailbox) branch was equally affected — the
+    docstring's advice to pass account+source_mailbox removed the
+    accounts x mailboxes multiplier but not the scan itself, and `sourceMb`
+    is routinely a 33,569-message INBOX.
+    """
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    @pytest.mark.parametrize(
+        "account,source_mailbox",
+        [(None, None), ("Gmail", "INBOX")],
+        ids=["cross-scan", "narrow"],
+    )
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_emitted_script_matches_only_the_indexed_id(
+        self, mock_run: MagicMock, connector: AppleMailConnector,
+        monkeypatch: pytest.MonkeyPatch,
+        account: str | None, source_mailbox: str | None,
+    ) -> None:
+        mock_run.return_value = "1"
+        monkeypatch.setattr(
+            connector, "find_message_by_message_id", lambda mid: "160989"
+        )
+        connector.update_message(
+            ["abc@example.com"], flag_color="orange",
+            account=account, source_mailbox=source_mailbox,
+        )
+        script = mock_run.call_args[0][0]
+        assert "message id is" not in script, (
+            "unindexed message-id match present — this is the #437 freeze"
+        )
+        assert "midBare" not in script
+        assert "whose id is" in script
+
+
+class TestUpdateMessageMatchesRfcMessageId:
+    """Bug A / #205-family: an RFC 5322 Message-ID must still produce a real
+    update, not a silent ``updated:0``.
+
+    Read tools hand back the RFC Message-ID on the IMAP path, which Mail's
+    numeric ``id`` never equals. #205 fixed that by matching ``message id``
+    inline in the same AppleScript pass, explicitly to avoid "a separate
+    resolver round-trip".
+
+    **#437 reverses the mechanism, not the guarantee.** That inline match is
+    UNINDEXED and freezes Mail (33,569 messages in Gmail's INBOX, per id).
+    The id is now resolved up front via `_resolve_bulk_ids`, so the pass
+    matches on the indexed numeric ``id``. These tests pin the *guarantee* —
+    an RFC id still updates — while `TestBulkBlockHasNoUnindexedArm` pins the
+    new mechanism.
     """
 
     RFC_ID = (
@@ -5018,22 +5173,26 @@ class TestUpdateMessageMatchesRfcMessageId:
         connector: AppleMailConnector,
     ) -> None:
         mock_run.return_value = "1"
+        mock_find.return_value = "160989"
 
         result = connector.update_message([self.RFC_ID], flag_color="orange")
 
         assert result == 1
-        # The pass must try the RFC message id (not only the numeric id),
-        # in the single existing AppleScript pass — no separate resolver
-        # round-trip.
+        # The guarantee (#205): an RFC id produces a real update, not a
+        # silent updated:0. The mechanism (#437): it was resolved to Mail's
+        # internal id first, so the emitted match is the INDEXED numeric one.
+        mock_find.assert_called_once_with(self.RFC_ID)
         script = mock_run.call_args[0][0]
-        # The pass tries the RFC message id; the message-id arm queries
-        # both the bare and <bracketed> forms (mirrors #232 /
-        # find_message_by_message_id), so other providers' bracketed
-        # storage still matches.
-        assert "message id is midBare" in script
-        assert 'message id is ("<" & midBare & ">")' in script
-        assert f'"{self.RFC_ID}"' in script
-        mock_find.assert_not_called()
+        assert '"160989"' in script
+        assert f'"{self.RFC_ID}"' not in script, (
+            "the raw RFC id reached AppleScript — it would hit the unindexed "
+            "message-id match and freeze Mail (#437)"
+        )
+        assert "message id is" not in script
+        # (#205 asserted `mock_find.assert_not_called()` here — the whole
+        # point of that fix was to avoid a resolver round-trip. #437 reverses
+        # that: the resolver is now indexed IMAP + binary search, while the
+        # inline match it was avoiding freezes Mail.)
         mock_run.assert_called_once()
 
     @patch.object(AppleMailConnector, "_run_applescript")


### PR DESCRIPTION
Fixes #437. **Last open issue on v0.11.0.**

## The freeze

`_bulk_repeat_block` matched each id twice: Mail's indexed integer `id`, then — when that missed — the **unindexed** `message id`. For an RFC 5322 Message-ID the first arm *always* misses, so the second always fired. AppleScript runs on Mail's UI thread, so that arm loaded every message in scope, once per id, up to the 100-item bulk cap.

Reachable through ordinary use: read tools emit bare RFC Message-IDs (#148), and `account`/`source_mailbox` are optional. Five mutating tools are affected, so a mid-batch freeze leaves the mutation partially applied.

## Both branches were affected — not just the cross-scan

The issue and the docstring both framed this as a cross-scan problem, with "pass `account` + `source_mailbox`" as the mitigation. That was half right. The narrow path emitted the same unindexed match against `sourceMb` — routinely a **33,569-message INBOX**. Scoping removed the mailbox-count multiplier, never the scan.

Fixing both is what makes the arm **removable** rather than merely avoidable.

## The fix

Resolve RFC ids to Mail's internal numeric ids *before* generating the script (new `_resolve_bulk_ids`). The emitted match is then always the indexed `whose id is N`, so the unindexed arm is dead code — deleted from both branches.

**This reverses #205's deliberate choice** to match inline and avoid "a separate resolver round-trip". That was sound when resolving meant an all-mailbox scan; since #434 the resolver is indexed IMAP + binary search, while the inline match freezes Mail. #205's *guarantee* — an RFC id produces a real update, never a silent `updated:0` — is unchanged and still tested.

**Ordering is the easy thing to get wrong.** Resolution runs *after* the IMAP fast paths, never before: those want RFC ids and batch them through `_or_message_id_criteria` (#316) into one OR-SEARCH per 50. Verified on real Mail that `test_flag_two_ids_resolves_via_single_or_search` still passes.

**Failure handling mirrors #425.** A definitively-absent id is dropped (the tools' best-effort partial-success contract); a batch where nothing resolved *and* something was unreachable raises, rather than reporting `updated: 0` — which would be "couldn't check" presented as "doesn't exist".

## Verification

```
1640 unit passed (was 1627)
make check-all: All checks passed
update_message: CC 20, unchanged against the ceiling of 20
```

The integration test drives **the exact freezing shape** — RFC id, no `account`/`source_mailbox`, `flag_color` so IMAP can't take it — and asserts Mail answers a trivial AppleScript *while the bulk update runs*. Against pre-fix code that is an outright freeze.

## Two things found along the way

**The cross-scan over-counts.** It visits every mailbox of every account with no `exit repeat` after a match, so a Gmail message visible under several labels increments the counter once per mailbox — my first integration run returned `2` for one message. This **predates #437** (the old unindexed arm matched the same way in each mailbox), so it's out of scope here, but `update_message` reporting 2 for one logical message is misleading. Worth its own issue.

**Batching is the obvious follow-up.** Resolution is per-id (~1.5s each), so a 100-id batch could take ~2 minutes — slow, bounded, never freezing. One OR-SEARCH per account for all arrival dates plus a single osascript doing N binary searches would make it seconds. Deliberately not on the release-blocking path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)