### PR TITLE
release: v0.11.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-mail-fast-mcp",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "Apple Mail for Claude Code — fast, security-first email management via MCP (macOS)",
   "owner": {
     "name": "Morgan Jeffries"
@@ -11,7 +11,7 @@
       "name": "apple-mail-fast",
       "displayName": "Apple Mail (Fast MCP)",
       "description": "Search, read, organize, draft, templates, rules, and inbox stats for Apple Mail — with an IMAP fast path and a security-first design. macOS only.",
-      "version": "0.10.2",
+      "version": "0.11.0",
       "source": "./",
       "author": {
         "name": "Morgan Jeffries"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-mail-fast",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "Apple Mail for Claude Code — search, read, organize, draft, templates, rules, and inbox stats via MCP, with an IMAP fast path. macOS only.",
   "author": {
     "name": "Morgan Jeffries"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Mail via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.10.2 | **Tests:** 1396 unit / 29 e2e / 62 integration | **Coverage:** 92%
+**Version:** v0.11.0 | **Tests:** 1640 unit / 30 e2e / 73 integration | **Coverage:** 92%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,14 @@ A large release dominated by one theme: **Mail.app no longer freezes.** Mail doe
 
 **Reverse-DNS stall inflating CI (#408):** `make_msgid` resolved the FQDN on every call; switched to `getfqdn` at import.
 
+### Known issues
+
+**Bulk mutations are slow for RFC Message-IDs (#450).** Removing the freeze (#437) meant resolving each RFC 5322 Message-ID to Mail's internal id before generating AppleScript, and that resolution measures **~16s per id** (1 id 15.3s, 10 ids 167s). It affects `mark_as_read`, `update_message`, `delete_messages`, `flag_message` and the verified move — but only on the AppleScript fallback, and only for RFC ids; **numeric ids are unaffected** (0.0000s). `mark_as_read` has no IMAP fast path, so it always pays; the others avoid it when `account` + `source_mailbox` engage the IMAP path.
+
+On accounts large enough that the old code froze Mail this is a clear improvement; on accounts where the unindexed scan happened to survive it is a real slowdown. Pass `account` + `source_mailbox`, or numeric ids, to stay off the slow path. Tracked in #450.
+
+**The shipped benchmark baseline is stale (#450).** It is stamped `0.10.2` because the bulk benchmarks cannot complete at the cost above. Do not treat it as a v0.11.0 reference.
+
 ### Chore
 
 Dependency lockfile refreshed to clear all `pip-audit` advisories (#348); `actions/checkout` 6 → 7 (#395) and `actions/setup-node` 4 → 7 with the pinned Node moved off EOL 20 to 22 (#423); `uvx` / `pip install` documented now that the package is on PyPI (#397). Research: a measured spike on a local-DB fast read path (#376, GO recommendation) and a competitive feature-gap analysis (#331).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-08-28
+
+A large release dominated by one theme: **Mail.app no longer freezes.** Mail does not index the RFC 5322 `message id` property, and AppleScript runs on Mail's UI thread — so every `whose message id is "X"` lookup loaded tens of thousands of message objects on the thread that draws the app. Four separate code paths did this (#415, #419, #432, #437); all four are now indexed or bounded, and an integration test asserts Mail answers a trivial AppleScript *while* each operation runs. Also here: the draft lifecycle works on localized Mail.app and Gmail, threads that come back incomplete now say so, and one new tool (24 → 25).
+
+### Added
+
+**`get_statistics` (#378):** consolidated inbox statistics over a mailbox and time window — message volume, read/unread/flagged counts, read ratio, and top senders by address or domain. A read-only roll-up computed from a single `search_messages` pass.
+
+**Claude Desktop `.mcpb` bundle (#332):** releases now attach an installable uv-type MCP bundle, built by [`scripts/build-mcpb.sh`](scripts/build-mcpb.sh).
+
+**Claude Code plugin (#398):** a marketplace manifest so the server can be installed as a Claude Code plugin.
+
+**Wrapper-free send (#322):** `create_draft(send_now=True)` submits a clean RFC 822 message over the account's SMTP server, so sent mail no longer carries Mail.app's cite-blockquote wrapper (FB11734014). Falls back to AppleScript when SMTP isn't configured. In test mode every resolved recipient is re-checked against the reserved-domain allowlist at the transport boundary (#175).
+
+**Guided IMAP app-password setup (#384):** `setup-imap` is provider-aware, walking through app-password creation per provider, with `--host` / `--port` overrides for accounts whose IMAP port Mail.app misreports (#405).
+
+**Richer IMAP reads (#389):** message bodies are decoded to text, `To`/`Cc` are surfaced, and attachment enumeration is reliable on the IMAP path.
+
+**Partial-thread signal on `get_thread` (#420):** responses carry an always-present `partial` boolean and, when true, a `partial_reason` (`imap_timeout`, `imap_unavailable`, `imap_auth_failed`, `imap_not_configured`, `imap_breaker_open`). The AppleScript fallback is subject-prefiltered and can return strictly fewer members than the full thread; previously a truncated conversation was indistinguishable from a complete one.
+
+### Changed
+
+**Import package renamed `apple_mail_mcp` → `apple_mail_fast_mcp` (#336):** breaking for anything importing the package directly. The distribution name and MCP tool surface are unchanged.
+
+**Keychain service prefixes rebranded (#337):** with a read-through fallback, so existing entries keep working without re-running `setup-imap`.
+
+**`find_message_by_message_id` resolves via IMAP, not an all-mailbox scan (#432):** an indexed `SEARCH HEADER Message-ID` (measured 0.14s over 61,880 messages) supplies the arrival date, then Mail is binary-searched by index — messages enumerate strictly newest-first with cheap positional access, so this is ~log₂(n) property reads. Accounts without IMAP now get a precise error rather than a scan; a lookup that cannot be completed raises instead of reporting the message absent.
+
+**Bulk mutations resolve ids before generating AppleScript (#437):** `update_message`, `delete_messages`, `flag_message`, `mark_as_read` and the verified-move path convert RFC Message-IDs to Mail's internal numeric ids up front, so the emitted match is always the indexed `whose id is N`. This reverses the #205-family decision to match `message id` inline and avoid a resolver round-trip — sound when resolving meant an all-mailbox scan, but the inline match froze Mail while the resolver no longer does.
+
+### Fixed
+
+**`get_thread` froze Mail on large mailboxes (#415, #419):** an RFC Message-ID anchor fell through to the unindexed all-mailbox scan, and a numeric id emitted `message id is "N"` branches across every account × mailbox — either wedged Mail's UI for >100s. RFC ids now resolve over indexed IMAP; numeric ids take a bounded probe of Mail's unified `inbox` / `sent mailbox` (1.3s vs 3.0s for the full walk on a 33k-message account).
+
+**Bulk mutations froze Mail once per id (#437):** the two-arm match in `_bulk_repeat_block` fell to the unindexed `message id` arm for every RFC id, on **both** the cross-scan and the "narrow" single-mailbox path — scoping removed the mailbox-count multiplier but never the scan, and `sourceMb` is routinely a 33,569-message INBOX. The arm is deleted rather than avoided.
+
+**A real message could be reported as missing (#425):** `_resolve_anchor_via_imap` could not distinguish "this account does not have it" from "this account could not be checked" — `OSError` is a fallback exception, so a socket timeout on the account holding the message was swallowed, and `get_thread` raised `MailMessageNotFoundError` advising the user to re-run `setup-imap` on a correctly configured account. Indeterminate lookups now raise `MailAnchorLookupIncompleteError` (`error_type: "anchor_lookup_incomplete"`, `retryable: true`); only an all-accounts-definitive miss reports absence.
+
+**`create_draft(seed="reply")` returned an empty `draft_id` (#421):** the id-bridging diff scanned Mail's unified drafts mailbox 0.5s after saving, but a saved draft takes 12.6–19.6s to surface — so the scan found nothing and returned the empty string it was initialised to, silently. #407 exposed this by making the scan fast; its slowness had been the only thing covering the sync lag. The wait is now a bounded poll budgeted from the connector timeout. Affected every AppleScript save-as-draft, not just replies.
+
+**Draft lifecycle broke on localized Mail.app and Gmail (#407):** `delete_draft` / `update_draft` / `get_draft_state` returned `draft_not_found` on non-English Mail.app (folder-name matching missed e.g. "Entwürfe") and on Gmail (the account-wide resolver returned the All Mail *mirror* of the draft, whose id the Drafts-scoped loops can never match). Both now iterate Mail's unified, locale-independent `drafts mailbox`.
+
+**AppleScript date literals parsed against the user's locale (#436):** `date "2026-08-09 11:03:51"` evaluated to *October 8, 12177* — silently, raising nothing, so any filter built on it just matched nothing. All dates are built from components via `_construct_as_date_var`, and [`check_applescript_safety.sh`](scripts/check_applescript_safety.sh) now fails the build on a `date "..."` literal.
+
+**Non-ASCII IMAP search and encoded-word headers (#392):** Korean (and other non-ASCII) search terms work, and encoded-word headers decode correctly.
+
+**Forwarded `rfc822` 0-byte payload and IMAP attachment-enumeration divergence (#385, #386).**
+
+**Reverse-DNS stall inflating CI (#408):** `make_msgid` resolved the FQDN on every call; switched to `getfqdn` at import.
+
+### Chore
+
+Dependency lockfile refreshed to clear all `pip-audit` advisories (#348); `actions/checkout` 6 → 7 (#395) and `actions/setup-node` 4 → 7 with the pinned Node moved off EOL 20 to 22 (#423); `uvx` / `pip install` documented now that the package is on PyPI (#397). Research: a measured spike on a local-DB fast read path (#376, GO recommendation) and a competitive feature-gap analysis (#331).
+
 ## [0.10.2] - 2026-06-13
 
 A bug-fix patch release for four reliability and data-integrity issues surfaced from real Claude Desktop usage on Gmail and iCloud: a full-body read that could crash the whole server, a Gmail label move that silently trashed the message, an IMAP search that silently dropped matching results, and an attachment save that hung for minutes on Gmail. No new tools (still 24).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An MCP server that provides programmatic access to Apple Mail, enabling AI assistants like Claude to read, send, search, and manage emails on macOS.
 
-> ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-fast-mcp==0.10.2`) and review the [CHANGELOG](CHANGELOG.md) before upgrading.
+> ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-fast-mcp==0.11.0`) and review the [CHANGELOG](CHANGELOG.md) before upgrading.
 
 ## Tools (25)
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "apple-mail-fast-mcp",
   "display_name": "Apple Mail (Fast MCP)",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "MCP server for Apple Mail — search, read, organize, draft, templates, rules, and inbox stats, with an IMAP fast path and a security-first design.",
   "long_description": "A local, security-first MCP server for Apple Mail on macOS. Reads and organizes mail via AppleScript with an optional IMAP fast path for large mailboxes. 25 tools across search/read, drafts, mailbox & rule CRUD, attachments, templates, and inbox statistics. No telemetry; destructive operations are gated; a --read-only mode is available. See the README for IMAP setup and the read/write server split.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "apple-mail-fast-mcp"
-version = "0.10.2"
+version = "0.11.0"
 description = "MCP server for Apple Mail integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/release_artifact_waivers.txt
+++ b/release_artifact_waivers.txt
@@ -14,4 +14,7 @@
 # Entries are per-release; prune old ones freely. See
 # docs/guides/RELEASE_ARTIFACTS.md.
 
+v0.11.0 benchmark #450 CANNOT be captured: #437 made bulk mutations cost ~16s per RFC Message-ID (measured 1 id=15.3s, 10 ids=167s), and the bulk benchmarks use 50 ids x 5 runs, so the suite cannot finish. Refreshing is blocked on #450, not skipped for convenience. NOTE: this release changed perf substantially (#415/#419/#432/#434/#437), so the shipped baseline is knowingly stale and v0.11.1 must not trust it for comparison.
+v0.11.0 eval #373 OPENROUTER_API_KEY unavailable on this runner (same cause as v0.10.2). Staler than last release: the tool surface grew 24 -> 25 (get_statistics, #378) and get_thread gained partial/partial_reason fields (#420), so scores are NOT expected to reproduce unchanged. Re-run tracked in #373.
+
 v0.10.2 eval #373 additive tool-surface change (still 24 tools: added optional account/mailbox to save_attachments, content_truncated to get_messages, deprecated gmail_mode); OPENROUTER_API_KEY unavailable on the release runner, scores expected to reproduce, re-run tracked. (Benchmark baseline IS refreshed this release — #364 changed move_messages timing.)

--- a/src/apple_mail_fast_mcp/__init__.py
+++ b/src/apple_mail_fast_mcp/__init__.py
@@ -4,4 +4,4 @@ Apple Mail MCP Server
 A Model Context Protocol server for Apple Mail integration.
 """
 
-__version__ = "0.10.2"
+__version__ = "0.11.0"

--- a/tests/benchmarks/test_attachments.py
+++ b/tests/benchmarks/test_attachments.py
@@ -18,9 +18,15 @@ from .conftest import (
 @pytest.fixture(scope="module")
 def message_with_attachment(
     connector: AppleMailConnector, test_account: str
-) -> str:
+) -> tuple[str, str]:
     """Find a message in the test account that has at least one
-    attachment. Skips the module if none exists."""
+    attachment. Returns ``(message_id, mailbox)``. Skips if none exists.
+
+    The mailbox is returned, not discarded: `save_attachments` requires
+    `account` + `mailbox` for an RFC Message-ID since #415, and that pair
+    is also what engages the #371 IMAP fast path — so this benchmark
+    measures the call shape callers are meant to use.
+    """
     for mb in ("INBOX", "Archive", "Sent Messages"):
         try:
             results = connector.search_messages(
@@ -29,7 +35,7 @@ def message_with_attachment(
         except Exception:
             continue
         if results:
-            return results[0]["id"]
+            return results[0]["id"], mb
     pytest.skip(
         f"No messages with attachments in account {test_account!r}. "
         f"Benchmark requires at least one such message in INBOX, Archive, "
@@ -39,7 +45,8 @@ def message_with_attachment(
 
 def test_save_attachments_one_file(
     connector: AppleMailConnector,
-    message_with_attachment: str,
+    message_with_attachment: tuple[str, str],
+    test_account: str,
     tmp_path: Path,
     baselines: dict[str, float],
     capture_mode: bool,
@@ -49,16 +56,34 @@ def test_save_attachments_one_file(
     Each iteration uses a fresh subdirectory to avoid filename-collision
     overwrites, but does NOT redownload from the IMAP server — Mail.app
     serves attachments from its local cache for read messages.
+
+    Passes `account` + `mailbox`: since #415 an RFC Message-ID without them
+    is refused outright (the all-mailbox `whose message id` scan freezes
+    Mail), so the un-scoped call this used to make has been failing since
+    that guard landed — benchmarks aren't in CI, so it went unnoticed.
     """
     name = "save_attachments_one_file"
+    message_id, mailbox = message_with_attachment
 
     iteration = [0]
+
+    # Scope ONLY an RFC Message-ID. `search_messages` emits the RFC id on the
+    # IMAP path but Mail's numeric id when it degrades to AppleScript, so the
+    # form here is not deterministic. A numeric id must go unscoped: the #415
+    # guard only rejects "@" ids, `whose id is N` is indexed and safe, and
+    # passing account+mailbox with a numeric id routes it to an IMAP fetch
+    # that cannot use it.
+    scope = (
+        {"account": test_account, "mailbox": mailbox}
+        if "@" in message_id
+        else {}
+    )
 
     def run() -> None:
         iteration[0] += 1
         out_dir = tmp_path / f"run_{iteration[0]}"
         out_dir.mkdir()
-        connector.save_attachments(message_with_attachment, out_dir)
+        connector.save_attachments(message_id, out_dir, **scope)
 
     result: BenchmarkResult = measure_median(run, name=name)
     assert_within_baseline(name, result, baselines, capture_mode)

--- a/tests/e2e/test_mcp_tools.py
+++ b/tests/e2e/test_mcp_tools.py
@@ -151,11 +151,15 @@ INVOCATION_CASES: list[tuple[str, dict[str, Any], str, Any]] = [
         {"id": "msg-1", "subject": "s", "from": "a@example.com"},
     ),
     (
+        # #420: the tool reads `_get_thread_with_status`, not `get_thread` —
+        # it returns (members, degraded_reason) so a partial thread can be
+        # flagged rather than passed off as complete.
         "get_thread",
         {"message_id": "msg-1"},
-        "get_thread",
-        [{"id": "msg-1", "subject": "Q3", "sender": "a@b",
-          "date_received": "Mon", "read_status": True, "flagged": False}],
+        "_get_thread_with_status",
+        ([{"id": "msg-1", "subject": "Q3", "sender": "a@b",
+           "date_received": "Mon", "read_status": True, "flagged": False}],
+         None),
     ),
     (
         "get_statistics",

--- a/uv.lock
+++ b/uv.lock
@@ -71,7 +71,7 @@ wheels = [
 
 [[package]]
 name = "apple-mail-fast-mcp"
-version = "0.10.2"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Cuts **v0.11.0** — 39 issues closed. Milestone is at 0 open.

## Headline

**Mail.app no longer freezes.** Mail doesn't index the RFC 5322 `message id` property and AppleScript runs on Mail's UI thread, so every `whose message id is "X"` loaded tens of thousands of message objects on the thread that draws the app. Four code paths did this — #415, #419, #432, #437 — and all four are now indexed or bounded, with an integration test asserting Mail answers a trivial AppleScript *while* each operation runs.

Also: draft lifecycle works on localized Mail.app and Gmail (#407, #421), incomplete threads say so (#420), a real message is never reported missing because a probe timed out (#425), and one new tool (24 → 25).

## Two red tests fixed at the gate

Neither is in CI, so both had been silently red:

- **e2e** — red since #430. The `get_thread` row stubbed the connector's `get_thread`, but #420 moved the tool onto `_get_thread_with_status`, which returns `(members, degraded_reason)`. #257 says a pre-existing e2e failure is a release-blocker, not something to ship around.
- **benchmark** — red since #415's `_reject_rfc_id_scan` guard landed mid-cycle; `test_attachments` called `save_attachments` with an RFC id and no `account`/`mailbox`, which that guard refuses.

## Known issue shipped deliberately — #450

Removing the freeze meant resolving RFC Message-IDs to Mail internal ids per call, and that measures **~16s per id** (1 id 15.3s, 10 ids 167s; numeric ids 0.0000s). `mark_as_read` has no IMAP fast path so it always pays.

Where Mail used to freeze this is a clear win; where the old unindexed scan happened to survive it's a real slowdown. It's in the CHANGELOG under **Known issues** rather than shipped quietly, and tracked in #450 on v0.11.1.

I attempted the obvious fix (#446, batch the lookups), measured it at **2× slower**, and reverted it — reading any Mail property costs ~155ms and isn't cached, so batching buys nothing and loses the first-match early exit. #446 is closed as superseded.

## Artifacts — both waived with tracking issues

- **benchmark baseline (#450)** — cannot be captured; the bulk benchmarks use 50 ids × 5 runs at ~16s/id. Stays stamped `0.10.2` and is **knowingly stale**; v0.11.1 must not use it as a comparison point.
- **eval snapshot (#373)** — no `OPENROUTER_API_KEY`, same as v0.10.2, but staler: tool surface grew 24 → 25 and `get_thread` gained `partial`/`partial_reason`, so scores are **not** expected to reproduce unchanged.

## Validation

```
version-sync / parity / complexity / dependencies / applescript-safety / docs : PASS
release-artifacts : OK (both waived)
unit : 1640 passed
e2e  : 30 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)