### PR TITLE
docs(#454): preserve AI co-author attribution

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -8,3 +8,7 @@
 # Subject: 50 chars or less, imperative mood
 # Body: Wrap at 72 chars, explain WHAT and WHY
 # Footer: Reference issues (Closes #N), breaking changes
+# AI-assisted work: add the actual contributing agent after a blank line.
+# Codex example (uncomment only when Codex contributed):
+# Co-authored-by: Codex <codex@openai.com>
+# Preserve existing human and Claude co-author trailers when squash merging.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,24 @@ GitHub is the source of truth for planned work and status. Follow
 merge, not the ordinary PR squash workflow. Read the release reference only when
 performing release work; setup or feature work does not execute a release.
 
+## Commit attribution
+
+Keep the human contributor's Git author identity. For work materially authored
+with an AI agent, append the appropriate `Co-authored-by` trailer to the commit
+message, separated from the body by a blank line. Codex contributions use:
+
+```text
+Co-authored-by: Codex <codex@openai.com>
+```
+
+For Claude-assisted work, retain the established Claude model attribution using
+`noreply@anthropic.com`; use the actual known model name, not a guessed version.
+Credit only agents that contributed to the change, and preserve other authors.
+Include the same attribution in PR descriptions. Before squash merging, assemble
+an explicit merge message preserving all legitimate co-author trailers, then
+verify the merged commit. A PR-body edit alone cannot change a merged commit's
+authorship. See [CONTRIBUTING.md](CONTRIBUTING.md) for retrospective corrections.
+
 ## Setup and validation
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,25 @@ make test-integration  # Real Mail.app tests
 3. Update `docs/reference/TOOLS.md` if you added/changed a tool
 4. PR description references the issue (`Closes #N`)
 
+## AI-assisted contributions
+
+Preserve the human contributor's Git author identity and credit an AI agent that
+materially contributed with a `Co-authored-by` trailer after a blank line in the
+commit message. Use `Co-authored-by: Codex <codex@openai.com>` for Codex. For Claude,
+retain the existing convention of the known Claude model name and
+`noreply@anthropic.com`. Do not add agent credit to unrelated human-only work.
+
+Include the attribution in the PR description, preserve legitimate trailers in
+the final squash message, and inspect the merged commit to verify they survived.
+GitHub account/contributor-graph linking depends on the email's association with
+a GitHub account; recording a trailer does not guarantee that display.
+
+For already-merged work, a correction in the PR description plus an explicitly
+linked follow-up commit can record omitted credit without rewriting history.
+Neither changes the original commit's authorship. Rewriting a published commit
+requires explicit maintainer authorization and compatible branch protections;
+do not disable protections just to change attribution.
+
 ## Coding Standards
 
 - **Type annotations** on all functions (mypy strict mode)

--- a/docs/guides/CODEX.md
+++ b/docs/guides/CODEX.md
@@ -78,3 +78,12 @@ also be needed. Never use production mail or send email to validate Codex setup.
 This setup overlaps the orientation cleanup in GitHub #424: shared guidance drops
 derived counts and documents both network backends. A broader audit of historical
 domain examples remains separate; check current code and API docs when using them.
+
+## Attribution correction for the initial setup
+
+Codex co-authored the initial setup in [PR #453](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/pull/453),
+merged as `ed0cfbc3f2da376e8d96b379c0caabce481d870b`. Its commit message omitted
+the co-author trailer. This acknowledgment and the follow-up tracked in
+[#454](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/issues/454) record
+that credit retrospectively without changing the original commit's metadata.
+Future contributions follow the attribution rules in [AGENTS.md](../../AGENTS.md).

--- a/docs/guides/MERGE_AND_STATUS.md
+++ b/docs/guides/MERGE_AND_STATUS.md
@@ -17,10 +17,18 @@ for merging and tagging; retain the contributor and milestone reporting below.
    gh pr checks <number> --watch
    ```
 
-3. **Squash merge** the PR and delete the branch:
+3. **Preserve attribution, then squash merge** the PR and delete the branch.
+   Read the PR's commit messages and description; collect legitimate
+   `Co-authored-by` trailers (including human contributors and any contributing
+   agents). Write the final squash body to a temporary file with a blank line
+   before the deduplicated trailers. Do not rely on GitHub's default squash
+   message to retain them. Keep the human author identity unchanged.
    ```bash
-   gh pr merge <number> --squash --delete-branch
+   gh pr merge <number> --squash --delete-branch --body-file /tmp/merge-body.md
    ```
+   Use the exact prepared file path. After merging, inspect the resulting commit
+   body and verify the trailers. A missing trailer must be reported; do not
+   silently rewrite published history to repair it.
 
 4. **Switch to main and pull:**
    ```bash


### PR DESCRIPTION
## Linked issue

Closes #454
Related to #452 and #453

## Summary

The first Codex setup commit omitted the AI co-author credit used by existing Claude Code contributions. Add a shared attribution convention for assisted commits and PRs, preserve legitimate co-author trailers in explicit squash messages, and verify the merged result. Keep the human Git author identity unchanged.

Record Codex's contribution to #453 in the setup guide and this correction commit. PR #453 now also carries a retrospective acknowledgment. The original commit ed0cfbc3f2da376e8d96b379c0caabce481d870b retains its metadata; no history or branch protections were changed.

## Test plan

- [x] `make check-all`: 1,640 unit tests and all validation gates passed.
- [x] `git interpret-trailers --parse` recognizes the Codex trailer; inspect the actual pushed commit as well.
- [x] Documentation links and `git diff --check` passed after the acknowledgment was added.
- No integration/e2e runs: documentation/template changes only, no real mail accessed.

## Checklist

- [x] Issue-linked branch and v0.11.1 milestone
- [x] Shared agent/contributor guidance and commit template updated
- [x] No application behavior or credential changes
- [x] No CHANGELOG or release-version changes

Co-authored-by: Codex <codex@openai.com>
